### PR TITLE
feat: Adds support for edxnotes

### DIFF
--- a/accordion/accordion.py
+++ b/accordion/accordion.py
@@ -40,9 +40,9 @@ class AccordionXBlock(XBlock):
 
     def get_html(self):
         """
-        This method returns the HTML generated for the LMS.
+        Student notes helper that returns the HTML generated for the LMS.
 
-        This is specifically used to support edx-notes for Accordion XBlock,
+        It is specifically used to support edx-notes for Accordion XBlock,
         this provides an achor to be added to the HTML where the edx-notes HTML can be injected.
         """
         html = self.resource_string("static/html/accordion_student.html")

--- a/accordion/accordion.py
+++ b/accordion/accordion.py
@@ -11,8 +11,16 @@ try:
     import importlib_resources
 except ImportError:  # pragma: no cover
     from importlib import resources as importlib_resources
+try:
+    from xmodule.edxnotes_utils import edxnotes
+except ModuleNotFoundError:
+
+    def edxnotes(func):  # noqa: D103
+        return func
 
 
+@XBlock.needs("user")
+@edxnotes
 class AccordionXBlock(XBlock):
     """
     Accordion XBlock.
@@ -30,11 +38,21 @@ class AccordionXBlock(XBlock):
         data = importlib_resources.files("accordion").joinpath(path).read_text("utf8")
         return data
 
+    def get_html(self):
+        """
+        This method returns the HTML generated for the LMS.
+
+        This is specifically used to support edx-notes for Accordion XBlock,
+        this provides an achor to be added to the HTML where the edx-notes HTML can be injected.
+        """
+        html = self.resource_string("static/html/accordion_student.html")
+        return html
+
     def student_view(self, context=None):  # pylint: disable=unused-argument
         """
         Create primary view of the AccordionXBlock, shown to students when viewing courses.
         """
-        frag = Fragment()
+        frag = Fragment(self.get_html())
         frag.add_javascript(self.resource_string("static/student.js"))
         frag.add_css_url(self.runtime.local_resource_url(self, "public/student-ui.css"))
         frag.initialize_js(

--- a/accordion/static/html/accordion_student.html
+++ b/accordion/static/html/accordion_student.html
@@ -1,0 +1,2 @@
+<div id="xblock-accordion-student">
+</div>

--- a/accordion/static/student.js
+++ b/accordion/static/student.js
@@ -1,6 +1,7 @@
 function AccordionBlock(runtime, element, data) {
+  let accordionHtml = $(element).find('#xblock-accordion-student');
   (async () => {
-    const {renderBlock} = await import(data.url);
-    renderBlock(element, data);
+    const { renderBlock } = await import(data.url);
+    renderBlock(accordionHtml, data);
   })();
 }


### PR DESCRIPTION
## Description

Adds the ability to make student notes and activate it on branching xblock.

## Testing instructions

- Enable `notes` plugin in tutor and install it, if it's not available
- `tutor plugin install notes`
- `tutor plugin enable notes`
- Make sure that Accordion XBlock is mounted in devstack
- Check `tutor mounts list` and see if XBlock is mounted 
- If the XBlock is not mounted, you can switch to the repository `cd bracnhing-xblock` and `tutor mounts add .`
- Build Images `tutor image build openedx-dev`
- `tutor image build notes`
- Once the Branching XBlock is installed, enable it in the advanced settings and use it in a course
-  Check if you can make student notes
- Now change the branch in Accordion XBlock to `farhaan/enabled-notes`
- Restart lms and cms `tutor dev restart lms cms`
- Now try again to make notes
- Student notes should be available

:Note: 

If notes is not working in HTML XBlock as well we need to set `USE_EXTRACTED_HTML_BLOCK` in [common/settings](https://github.com/openedx/openedx-platform/blob/master/openedx/envs/common.py#L2078) to `True`

`Private Ref`: [BB-10465](https://tasks.opencraft.com/browse/BB-10465)

**Merge checklist:**
Check off if complete *or* not applicable:
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Fixup commits are squashed away
- [ ] Unit tests added/updated
- [ ] Manual testing instructions provided
- [ ] Noted any: Concerns, dependencies, migration issues, deadlines, tickets
